### PR TITLE
refactor: 拆分 settings-modal.js 為三個職責清晰的模組

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -661,6 +661,8 @@
     <!-- Other -->
     <script src="/static/js/about-modal.js"></script>
     <script src="/static/js/settings-manager.js"></script>
+    <script src="/static/js/settings-data.js"></script>
+    <script src="/static/js/settings-google.js"></script>
     <script src="/static/js/settings-modal.js"></script>
     <script src="/static/js/calendar-modal.js"></script>
     <script src="/static/js/sync-panel.js"></script>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -339,24 +339,72 @@
 
 /* Mobile responsiveness */
 @media (max-width: 768px) {
+    /* General utilities */
     .mobile-stack {
         flex-direction: column;
     }
-    
+
     .mobile-full-width {
         width: 100% !important;
     }
-    
+
     .mobile-hidden {
         display: none !important;
     }
-    
+
     .mobile-text-sm {
         font-size: 0.875rem;
     }
-    
+
     .mobile-p-2 {
         padding: 0.5rem;
+    }
+
+    /* Code blocks */
+    .markdown-preview pre {
+        border-radius: 0.25rem;
+        margin: 0.75rem 0;
+        padding: 0.75rem;
+    }
+
+    .copy-btn {
+        opacity: 1;
+        position: static;
+        margin: 0.5rem 0 0 0;
+        display: block;
+        width: 100%;
+    }
+
+    .mermaid-container {
+        margin: 1rem 0;
+        padding: 0.75rem;
+        border-radius: 0.25rem;
+    }
+
+    /* Focused layout */
+    #history-drawer {
+        width: 100% !important;
+    }
+
+    #breadcrumb-nav {
+        font-size: 0.75rem;
+    }
+
+    #breadcrumb-nav .mx-1 {
+        margin-left: 0.125rem;
+        margin-right: 0.125rem;
+    }
+
+    #card-stack {
+        padding: 0.5rem;
+    }
+
+    #card-stack .plan-card {
+        border-radius: 0.375rem;
+    }
+
+    #layout-mode-btn span {
+        display: none;
     }
 }
 
@@ -590,6 +638,17 @@
 .panel-title {
     color: var(--color-title-text);
     font-weight: 600;
+    cursor: pointer;
+    user-select: none;
+    transition: opacity 0.2s ease;
+}
+
+.panel-title:hover {
+    opacity: 0.8;
+}
+
+.panel-title:active {
+    opacity: 0.6;
 }
 
 .title-text {
@@ -745,17 +804,6 @@
     white-space: pre-wrap;
 }
 
-/* Theme-specific adjustments for code blocks */
-.theme-dark .markdown-preview pre {
-    background-color: var(--color-secondary);
-    border-color: var(--color-border);
-}
-
-.theme-light .markdown-preview pre {
-    background-color: var(--color-secondary);
-    border-color: var(--color-border);
-}
-
 /* Language label for code blocks */
 .code-language-label {
     position: absolute;
@@ -768,28 +816,6 @@
     letter-spacing: 0.05em;
 }
 
-/* Responsive design for code blocks */
-@media (max-width: 768px) {
-    .markdown-preview pre {
-        border-radius: 0.25rem;
-        margin: 0.75rem 0;
-        padding: 0.75rem;
-    }
-    
-    .copy-btn {
-        opacity: 1;
-        position: static;
-        margin: 0.5rem 0 0 0;
-        display: block;
-        width: 100%;
-    }
-    
-    .mermaid-container {
-        margin: 1rem 0;
-        padding: 0.75rem;
-        border-radius: 0.25rem;
-    }
-}
 
 /* Panel Maximize Feature Styles */
 .panel-maximized {
@@ -955,20 +981,6 @@
     height: 100% !important;
 }
 
-.panel-title {
-    cursor: pointer;
-    user-select: none;
-    transition: opacity 0.2s ease;
-}
-
-.panel-title:hover {
-    opacity: 0.8;
-}
-
-.panel-title:active {
-    opacity: 0.6;
-}
-
 /* Print styles */
 @media print {
     .no-print {
@@ -1031,20 +1043,25 @@
    Google Auth Styles (002-google-drive-storage)
    ======================================== */
 
+/* Google auth buttons - shared styles */
+#google-connect-btn,
+#google-disconnect-btn {
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border-radius: 0.375rem;
+    transition: all 0.2s ease;
+    cursor: pointer;
+}
+
 /* Google connect button */
 #google-connect-btn {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    font-size: 0.875rem;
-    font-weight: 500;
     color: #374151;
     background-color: #ffffff;
     border: 1px solid #d1d5db;
-    border-radius: 0.375rem;
-    transition: all 0.2s ease;
-    cursor: pointer;
 }
 
 #google-connect-btn:hover {
@@ -1055,20 +1072,14 @@
 
 #google-connect-btn:focus {
     outline: none;
-    ring: 2px solid #3b82f6;
+    box-shadow: 0 0 0 2px #3b82f6;
 }
 
 /* Google disconnect button */
 #google-disconnect-btn {
-    padding: 0.5rem 1rem;
-    font-size: 0.875rem;
-    font-weight: 500;
     color: #dc2626;
     background-color: #fef2f2;
     border: 1px solid #fecaca;
-    border-radius: 0.375rem;
-    transition: all 0.2s ease;
-    cursor: pointer;
 }
 
 #google-disconnect-btn:hover {
@@ -1256,7 +1267,6 @@
 .settings-tab-content .p-4.rounded-lg:hover {
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
-}
 
 /* ========================================
    Focused Layout - Plan Card Styles
@@ -1381,37 +1391,6 @@
 /* ========================================
    Focused Layout - Mobile Responsive
    ======================================== */
-
-@media (max-width: 768px) {
-    /* Drawer goes full-width on mobile */
-    #history-drawer {
-        width: 100% !important;
-    }
-
-    /* Simplify breadcrumb on mobile */
-    #breadcrumb-nav {
-        font-size: 0.75rem;
-    }
-
-    #breadcrumb-nav .mx-1 {
-        margin-left: 0.125rem;
-        margin-right: 0.125rem;
-    }
-
-    /* Card stack reduce padding */
-    #card-stack {
-        padding: 0.5rem;
-    }
-
-    #card-stack .plan-card {
-        border-radius: 0.375rem;
-    }
-
-    /* Hide layout mode button text on mobile */
-    #layout-mode-btn span {
-        display: none;
-    }
-}
 
 @media (max-width: 480px) {
     /* Extra small screens */

--- a/static/js/settings-data.js
+++ b/static/js/settings-data.js
@@ -1,0 +1,137 @@
+// Settings Data Section - handles data import/export functionality
+
+class SettingsDataSection {
+    constructor() {
+        this.bindEvents();
+    }
+
+    /**
+     * Bind import/export event listeners
+     */
+    bindEvents() {
+        // Export button
+        const exportBtn = document.getElementById('export-data-btn');
+        if (exportBtn) {
+            exportBtn.addEventListener('click', () => {
+                this.handleExport();
+            });
+        }
+
+        // Import button
+        const importBtn = document.getElementById('import-data-btn');
+        if (importBtn) {
+            importBtn.addEventListener('click', () => {
+                const fileInput = document.getElementById('import-file-input');
+                if (fileInput) {
+                    fileInput.click();
+                }
+            });
+        }
+
+        // Import file input
+        const fileInput = document.getElementById('import-file-input');
+        if (fileInput) {
+            fileInput.addEventListener('change', (e) => {
+                if (e.target.files && e.target.files[0]) {
+                    this.handleImport(e.target.files[0]);
+                }
+            });
+        }
+    }
+
+    /**
+     * Handle data export
+     */
+    async handleExport() {
+        try {
+            Utils.showLoading('正在匯出資料...');
+
+            const result = await window.planAPI.exportData();
+
+            Utils.showSuccess(`成功匯出 ${result.file_count} 個檔案`);
+
+            // Trigger download
+            window.planAPI.downloadExport(result.filename);
+
+        } catch (error) {
+            console.error('Export failed:', error);
+            Utils.showError('匯出失敗: ' + error.message);
+        } finally {
+            Utils.hideLoading();
+        }
+    }
+
+    /**
+     * Handle data import
+     */
+    async handleImport(file) {
+        if (!file) {
+            Utils.showError('請選擇要匯入的 ZIP 檔案');
+            return;
+        }
+
+        try {
+            Utils.showLoading('正在驗證檔案...');
+
+            // 呼叫驗證 API
+            const validation = await window.planAPI.validateImport(file);
+
+            Utils.hideLoading();
+
+            // 如果有錯誤,顯示錯誤訊息並中斷
+            if (!validation.is_valid) {
+                const errorMessages = validation.errors.map(err =>
+                    `• ${err.message}`
+                ).join('\n');
+
+                Utils.showError(
+                    `驗證失敗,發現 ${validation.errors.length} 個錯誤:\n\n${errorMessages}\n\n請修正後重新上傳。`
+                );
+                return;
+            }
+
+            // 如果有警告,顯示但不中斷
+            if (validation.warnings && validation.warnings.length > 0) {
+                const warningMessages = validation.warnings.map(warn =>
+                    `• ${warn.message}`
+                ).join('\n');
+
+                console.warn('驗證警告:', warningMessages);
+            }
+
+            // 驗證通過,詢問是否繼續匯入
+            const confirmMessage = `驗證通過!\n\n` +
+                `檔案數量: ${validation.file_count} 個\n` +
+                (validation.warnings?.length > 0 ? `警告: ${validation.warnings.length} 個\n` : '') +
+                `\n確定要匯入這些資料嗎?\n(將覆蓋現有的同名檔案)`;
+
+            if (!confirm(confirmMessage)) {
+                Utils.showError('已取消匯入');
+                return;
+            }
+
+            // 執行匯入
+            Utils.showLoading('正在匯入資料...');
+
+            const importResult = await window.planAPI.executeImport(file);
+
+            Utils.hideLoading();
+            Utils.showSuccess(
+                `${importResult.message}\n\n` +
+                `匯入時間: ${new Date(importResult.imported_at).toLocaleString('zh-TW')}`
+            );
+
+            // 重新整理頁面以顯示新資料
+            setTimeout(() => {
+                window.location.reload();
+            }, 2000);
+
+        } catch (error) {
+            Utils.hideLoading();
+            Utils.showError(`匯入失敗: ${error.message}`);
+            console.error('Import error:', error);
+        }
+    }
+}
+
+window.SettingsDataSection = SettingsDataSection;

--- a/static/js/settings-google.js
+++ b/static/js/settings-google.js
@@ -1,0 +1,610 @@
+// Settings Google Section - handles Google Auth, Drive path, and Storage Mode
+
+class SettingsGoogleSection {
+    constructor() {
+        this.googleAuthStatus = null;
+        this.storageStatus = null;
+        this.bindEvents();
+    }
+
+    /**
+     * Initialize: load statuses and register auth change listener
+     */
+    async init() {
+        await this.loadGoogleAuthStatus();
+        await this.loadStorageStatus();
+
+        // Listen for Google auth status changes
+        if (window.googleAuthManager) {
+            window.googleAuthManager.onStatusChange((status) => {
+                this.googleAuthStatus = status;
+                this.updateGoogleAuthUI();
+            });
+        }
+    }
+
+    /**
+     * Bind Google/storage event listeners
+     */
+    bindEvents() {
+        // Google Auth buttons
+        const googleConnectBtn = document.getElementById('google-connect-btn');
+        if (googleConnectBtn) {
+            googleConnectBtn.addEventListener('click', () => {
+                this.handleGoogleConnect();
+            });
+        }
+
+        const googleDisconnectBtn = document.getElementById('google-disconnect-btn');
+        if (googleDisconnectBtn) {
+            googleDisconnectBtn.addEventListener('click', () => {
+                this.handleGoogleDisconnect();
+            });
+        }
+
+        // Google Drive path input
+        const googleDrivePathInput = document.getElementById('google-drive-path-input');
+        if (googleDrivePathInput) {
+            googleDrivePathInput.addEventListener('input', (e) => {
+                this.validateGoogleDrivePath(e.target.value);
+            });
+            googleDrivePathInput.addEventListener('blur', (e) => {
+                this.handleGoogleDrivePathChange(e.target.value);
+            });
+        }
+
+        const saveGoogleDrivePathBtn = document.getElementById('save-google-drive-path-btn');
+        if (saveGoogleDrivePathBtn) {
+            saveGoogleDrivePathBtn.addEventListener('click', () => {
+                const input = document.getElementById('google-drive-path-input');
+                if (input) {
+                    this.saveGoogleDrivePath(input.value);
+                }
+            });
+        }
+
+        // Test connection button
+        const testConnectionBtn = document.getElementById('test-connection-btn');
+        if (testConnectionBtn) {
+            testConnectionBtn.addEventListener('click', () => {
+                this.handleTestConnection();
+            });
+        }
+
+        // 同步管理按鈕
+        const syncPanelBtn = document.getElementById('open-sync-panel-btn');
+        if (syncPanelBtn) {
+            syncPanelBtn.addEventListener('click', () => {
+                if (window.syncPanel) {
+                    if (window.settingsModal) window.settingsModal.hide();
+                    window.syncPanel.show();
+                }
+            });
+        }
+
+        // Storage mode radio buttons
+        const storageModeRadios = document.querySelectorAll('.storage-mode-radio');
+        storageModeRadios.forEach(radio => {
+            radio.addEventListener('change', (e) => {
+                this.handleStorageModeChange(e.target.value);
+            });
+        });
+    }
+
+    // ========================================
+    // Google Auth Methods
+    // ========================================
+
+    /**
+     * Load Google auth status
+     */
+    async loadGoogleAuthStatus() {
+        try {
+            if (window.googleAuthManager) {
+                await window.googleAuthManager.init();
+                this.googleAuthStatus = await window.googleAuthManager.getAuthStatus();
+                this.updateGoogleAuthUI();
+            }
+        } catch (error) {
+            console.error('Failed to load Google auth status:', error);
+            this.googleAuthStatus = { status: 'not_connected' };
+            this.updateGoogleAuthUI();
+        }
+    }
+
+    /**
+     * Update Google auth UI based on current status
+     */
+    updateGoogleAuthUI() {
+        const statusContainer = document.getElementById('google-auth-status');
+        const connectBtn = document.getElementById('google-connect-btn');
+        const disconnectBtn = document.getElementById('google-disconnect-btn');
+        const emailDisplay = document.getElementById('google-connected-email');
+
+        if (!statusContainer) return;
+
+        const status = this.googleAuthStatus;
+        const isConnected = status && status.status === 'connected';
+
+        if (connectBtn) {
+            connectBtn.style.display = isConnected ? 'none' : 'inline-block';
+        }
+
+        if (disconnectBtn) {
+            disconnectBtn.style.display = isConnected ? 'inline-block' : 'none';
+        }
+
+        if (emailDisplay) {
+            if (isConnected && status.user_email) {
+                emailDisplay.textContent = status.user_email;
+                emailDisplay.parentElement.style.display = 'flex';
+            } else {
+                emailDisplay.parentElement.style.display = 'none';
+            }
+        }
+
+        // Update status indicator
+        const statusIndicator = document.getElementById('google-auth-indicator');
+        if (statusIndicator) {
+            if (isConnected) {
+                statusIndicator.className = 'w-2 h-2 rounded-full bg-green-500';
+                statusIndicator.title = '已連結';
+            } else if (status && status.status === 'expired') {
+                statusIndicator.className = 'w-2 h-2 rounded-full bg-yellow-500';
+                statusIndicator.title = '授權過期';
+            } else {
+                statusIndicator.className = 'w-2 h-2 rounded-full bg-gray-400';
+                statusIndicator.title = '未連結';
+            }
+        }
+
+        // Update storage UI when auth status changes
+        this.updateStorageUI();
+
+        // 顯示/隱藏同步管理按鈕
+        const syncSection = document.getElementById('sync-management-section');
+        if (syncSection) {
+            syncSection.style.display = isConnected ? 'block' : 'none';
+        }
+    }
+
+    /**
+     * Handle Google account connection
+     */
+    async handleGoogleConnect() {
+        try {
+            Utils.showLoading('正在連結 Google 帳號...');
+
+            const result = await window.googleAuthManager.startAuth();
+
+            this.googleAuthStatus = result;
+            this.updateGoogleAuthUI();
+
+            // Reload storage status to get latest settings
+            await this.loadStorageStatus();
+
+            // Reload all plans to reflect data from current storage mode
+            if (window.app && typeof window.app.refreshAllPlans === 'function') {
+                await window.app.refreshAllPlans();
+            }
+
+            Utils.hideLoading();
+            Utils.showSuccess('已成功連結 Google 帳號');
+
+        } catch (error) {
+            Utils.hideLoading();
+            console.error('Google connect failed:', error);
+            Utils.showError('連結 Google 帳號失敗: ' + error.message);
+        }
+    }
+
+    /**
+     * Handle Google account disconnection
+     */
+    async handleGoogleDisconnect() {
+        if (!confirm('確定要解除 Google 帳號連結嗎？')) {
+            return;
+        }
+
+        try {
+            Utils.showLoading('正在解除連結...');
+
+            // If currently in Google Drive mode, switch to local first
+            const wasGoogleDriveMode = this.storageStatus?.mode === 'google_drive';
+            if (wasGoogleDriveMode) {
+                try {
+                    const result = await window.planAPI.updateStorageMode('local', this.storageStatus?.google_drive_path);
+                    this.storageStatus = result;
+                    this.updateStorageModeUI();
+                    this.updateStorageUI();
+
+                    // Dispatch event to update header icon
+                    window.dispatchEvent(new CustomEvent('storage-mode-changed', {
+                        detail: { mode: 'local', status: result }
+                    }));
+                } catch (switchError) {
+                    console.warn('Failed to switch storage mode, continuing with logout:', switchError);
+                }
+            }
+
+            if (window.googleAuthManager) {
+                await window.googleAuthManager.logout();
+            }
+
+            this.googleAuthStatus = { status: 'not_connected' };
+            this.updateGoogleAuthUI();
+
+            // Reload all plans to reflect data from local storage
+            if (window.app && typeof window.app.refreshAllPlans === 'function') {
+                await window.app.refreshAllPlans();
+            }
+
+            Utils.hideLoading();
+            Utils.showSuccess('已解除 Google 帳號連結');
+
+        } catch (error) {
+            Utils.hideLoading();
+            console.error('Google disconnect failed:', error);
+            Utils.showError('解除連結失敗: ' + error.message);
+        }
+    }
+
+    // ========================================
+    // Storage Settings Methods
+    // ========================================
+
+    /**
+     * Load storage status
+     */
+    async loadStorageStatus() {
+        try {
+            this.storageStatus = await window.planAPI.getStorageStatus();
+            this.updateStorageUI();
+            this.updateStorageModeUI();
+        } catch (error) {
+            console.error('Failed to load storage status:', error);
+            this.storageStatus = null;
+        }
+    }
+
+    /**
+     * Update storage UI based on current status
+     */
+    updateStorageUI() {
+        const pathInput = document.getElementById('google-drive-path-input');
+        const pathError = document.getElementById('google-drive-path-error');
+        const pathContainer = document.getElementById('google-drive-path-container');
+
+        if (pathInput && this.storageStatus) {
+            pathInput.value = this.storageStatus.google_drive_path || 'WorkPlanByCalendar';
+        }
+
+        // Show/hide path container based on Google auth status
+        if (pathContainer) {
+            const isConnected = this.googleAuthStatus?.status === 'connected';
+            pathContainer.style.display = isConnected ? 'block' : 'none';
+        }
+
+        // Clear error on load
+        if (pathError) {
+            pathError.textContent = '';
+            pathError.style.display = 'none';
+        }
+    }
+
+    /**
+     * Validate Google Drive path input
+     * @param {string} path - Path to validate
+     * @returns {object} Validation result { isValid, message }
+     */
+    validateGoogleDrivePath(path) {
+        const pathError = document.getElementById('google-drive-path-error');
+        const pathInput = document.getElementById('google-drive-path-input');
+        const saveBtn = document.getElementById('save-google-drive-path-btn');
+
+        let isValid = true;
+        let message = '';
+
+        // Validation rules
+        if (!path || path.trim().length === 0) {
+            isValid = false;
+            message = '路徑不可為空';
+        } else if (path.length > 255) {
+            isValid = false;
+            message = '路徑長度不可超過 255 字元';
+        } else if (path.includes('..')) {
+            isValid = false;
+            message = '路徑不可包含 ".."';
+        } else if (path.startsWith('/')) {
+            isValid = false;
+            message = '路徑必須為相對路徑（不可以 "/" 開頭）';
+        } else if (/[<>:"|?*]/.test(path)) {
+            isValid = false;
+            message = '路徑包含無效字元（不可包含 <>:"|?*）';
+        }
+
+        // Update UI
+        if (pathError) {
+            if (isValid) {
+                pathError.style.display = 'none';
+                pathError.textContent = '';
+            } else {
+                pathError.style.display = 'block';
+                pathError.textContent = message;
+            }
+        }
+
+        if (pathInput) {
+            if (isValid) {
+                pathInput.classList.remove('border-red-500');
+                pathInput.classList.add('border-gray-300', 'dark:border-gray-600');
+            } else {
+                pathInput.classList.remove('border-gray-300', 'dark:border-gray-600');
+                pathInput.classList.add('border-red-500');
+            }
+        }
+
+        if (saveBtn) {
+            saveBtn.disabled = !isValid;
+        }
+
+        return { isValid, message };
+    }
+
+    /**
+     * Handle Google Drive path change (on blur)
+     * @param {string} path - New path value
+     */
+    handleGoogleDrivePathChange(path) {
+        const trimmedPath = path.trim();
+        const pathInput = document.getElementById('google-drive-path-input');
+
+        if (pathInput) {
+            pathInput.value = trimmedPath;
+        }
+
+        this.validateGoogleDrivePath(trimmedPath);
+    }
+
+    /**
+     * Save Google Drive path
+     * @param {string} path - Path to save
+     */
+    async saveGoogleDrivePath(path) {
+        const trimmedPath = path.trim();
+
+        // Validate before saving
+        const validation = this.validateGoogleDrivePath(trimmedPath);
+        if (!validation.isValid) {
+            Utils.showError(validation.message);
+            return;
+        }
+
+        // Check if path actually changed
+        if (this.storageStatus?.google_drive_path === trimmedPath) {
+            Utils.showSuccess('路徑未變更');
+            return;
+        }
+
+        try {
+            Utils.showLoading('正在儲存路徑設定...');
+
+            await window.planAPI.updateGoogleDrivePath(trimmedPath);
+
+            // Update local state
+            if (this.storageStatus) {
+                this.storageStatus.google_drive_path = trimmedPath;
+            }
+
+            Utils.hideLoading();
+            Utils.showSuccess('Google Drive 路徑已更新');
+
+        } catch (error) {
+            Utils.hideLoading();
+            console.error('Failed to save Google Drive path:', error);
+            Utils.showError('儲存失敗: ' + error.message);
+        }
+    }
+
+    /**
+     * Handle storage mode change
+     * @param {string} newMode - New storage mode ('local' or 'google_drive')
+     */
+    async handleStorageModeChange(newMode) {
+        const currentMode = this.storageStatus?.mode || 'local';
+
+        // If no change, do nothing
+        if (newMode === currentMode) {
+            return;
+        }
+
+        // If switching to Google Drive, check auth status
+        if (newMode === 'google_drive') {
+            if (this.googleAuthStatus?.status !== 'connected') {
+                Utils.showError('請先連結 Google 帳號才能切換到 Google Drive 模式');
+                // Reset radio button
+                this.updateStorageModeUI();
+                return;
+            }
+
+            // Show confirmation dialog
+            if (!await this.confirmStorageModeSwitch('google_drive')) {
+                this.updateStorageModeUI();
+                return;
+            }
+        } else if (currentMode === 'google_drive') {
+            // Switching from Google Drive to local
+            if (!await this.confirmStorageModeSwitch('local')) {
+                this.updateStorageModeUI();
+                return;
+            }
+        }
+
+        // Execute mode switch
+        await this.executeStorageModeSwitch(newMode);
+    }
+
+    /**
+     * Confirm storage mode switch
+     * @param {string} targetMode - Target storage mode
+     * @returns {Promise<boolean>} User confirmation result
+     */
+    async confirmStorageModeSwitch(targetMode) {
+        let message;
+
+        if (targetMode === 'google_drive') {
+            message = `確定要切換到 Google Drive 模式嗎？\n\n` +
+                `切換後：\n` +
+                `• 計畫資料將儲存到 Google Drive\n` +
+                `• 需要網路連線才能存取資料\n` +
+                `• 現有本地資料不會自動同步`;
+        } else {
+            message = `確定要切換回本地模式嗎？\n\n` +
+                `切換後：\n` +
+                `• 計畫資料將儲存在本機\n` +
+                `• Google Drive 上的資料不會自動同步到本機`;
+        }
+
+        return confirm(message);
+    }
+
+    /**
+     * Execute storage mode switch
+     * @param {string} newMode - New storage mode
+     */
+    async executeStorageModeSwitch(newMode) {
+        try {
+            Utils.showLoading('正在切換儲存模式...');
+
+            const googleDrivePath = this.storageStatus?.google_drive_path;
+            const result = await window.planAPI.updateStorageMode(newMode, googleDrivePath);
+
+            // Update local state
+            this.storageStatus = result;
+            this.updateStorageModeUI();
+            this.updateStorageUI();
+
+            // Reload all plans to reflect data from new storage mode
+            if (window.app && typeof window.app.refreshAllPlans === 'function') {
+                await window.app.refreshAllPlans();
+            }
+
+            Utils.hideLoading();
+
+            const modeText = newMode === 'google_drive' ? 'Google Drive' : '本地';
+            Utils.showSuccess(`已切換到${modeText}模式`);
+
+            // Dispatch event for other components to react
+            window.dispatchEvent(new CustomEvent('storage-mode-changed', {
+                detail: { mode: newMode, status: result }
+            }));
+
+            // 切換到 Google Drive 模式時，自動開啟同步面板並比較
+            if (newMode === 'google_drive' && window.syncPanel) {
+                if (window.settingsModal) window.settingsModal.hide();
+                window.syncPanel.show(true);
+            }
+
+        } catch (error) {
+            Utils.hideLoading();
+            console.error('Storage mode switch failed:', error);
+
+            // Reset UI to current state
+            this.updateStorageModeUI();
+
+            // Show appropriate error message
+            if (error.message.includes('尚未完全實作')) {
+                Utils.showError('Google Drive 功能尚在開發中，敬請期待！');
+            } else {
+                Utils.showError('切換儲存模式失敗: ' + error.message);
+            }
+        }
+    }
+
+    /**
+     * Update storage mode UI
+     */
+    updateStorageModeUI() {
+        const currentMode = this.storageStatus?.mode || 'local';
+        const localRadio = document.getElementById('storage-mode-local');
+        const googleDriveRadio = document.getElementById('storage-mode-google-drive');
+
+        if (localRadio) {
+            localRadio.checked = currentMode === 'local';
+        }
+        if (googleDriveRadio) {
+            googleDriveRadio.checked = currentMode === 'google_drive';
+            // Disable Google Drive option if not connected
+            const isConnected = this.googleAuthStatus?.status === 'connected';
+            googleDriveRadio.disabled = !isConnected;
+
+            const label = document.querySelector('label[for="storage-mode-google-drive"]');
+            if (label) {
+                if (isConnected) {
+                    label.classList.remove('opacity-50', 'cursor-not-allowed');
+                } else {
+                    label.classList.add('opacity-50', 'cursor-not-allowed');
+                }
+            }
+        }
+    }
+
+    /**
+     * Handle test connection button click
+     */
+    async handleTestConnection() {
+        try {
+            Utils.showLoading('正在測試連線...');
+
+            const result = await window.planAPI.testGoogleDriveConnection();
+
+            Utils.hideLoading();
+
+            if (result.success) {
+                const details = result.details || {};
+                const message = `✓ ${result.message}\n\n` +
+                    `帳號: ${details.user_email || 'N/A'}\n` +
+                    `資料夾: ${details.base_folder || 'N/A'}\n` +
+                    `檔案數: ${details.file_count || 0}`;
+                Utils.showSuccess(message);
+            } else {
+                this.showGoogleDriveError(result);
+            }
+        } catch (error) {
+            Utils.hideLoading();
+            console.error('Connection test failed:', error);
+            Utils.showError('連線測試失敗: ' + error.message);
+        }
+    }
+
+    /**
+     * Show Google Drive error with friendly message
+     * @param {object} result - Error result from API
+     */
+    showGoogleDriveError(result) {
+        const errorType = result.details?.error_type;
+        let message = result.message;
+        let suggestion = '';
+
+        switch (errorType) {
+            case 'not_connected':
+                suggestion = '請先在設定中連結您的 Google 帳號';
+                break;
+            case 'auth_expired':
+                suggestion = '請重新連結 Google 帳號以更新授權';
+                break;
+            case 'network':
+                suggestion = '請檢查您的網路連線後再試';
+                break;
+            case 'quota_exceeded':
+                suggestion = '請稍後再試，或聯繫 Google 了解配額限制';
+                break;
+            default:
+                suggestion = '如果問題持續發生，請嘗試重新連結 Google 帳號';
+        }
+
+        Utils.showError(`${message}\n\n${suggestion}`);
+    }
+}
+
+window.SettingsGoogleSection = SettingsGoogleSection;

--- a/static/js/settings-modal.js
+++ b/static/js/settings-modal.js
@@ -6,9 +6,7 @@ class SettingsModal {
         this.modal = document.getElementById('settings-modal');
         this.isVisible = false;
         this.pendingSettings = null;
-        this.googleAuthStatus = null;
-        this.storageStatus = null;
-        
+
         this.init();
     }
 
@@ -23,21 +21,16 @@ class SettingsModal {
 
         this.bindEvents();
         this.loadCurrentSettings();
-        this.loadGoogleAuthStatus();
-        this.loadStorageStatus();
-        
+
         // Listen for settings updates from the manager
-        this.settingsManager.onSettingsUpdated((settings) => {
+        this.settingsManager.onSettingsUpdated(() => {
             this.loadCurrentSettings();
         });
-        
-        // Listen for Google auth status changes
-        if (window.googleAuthManager) {
-            window.googleAuthManager.onStatusChange((status) => {
-                this.googleAuthStatus = status;
-                this.updateGoogleAuthUI();
-            });
-        }
+
+        // Initialize sub-sections (event binding handled internally)
+        this.dataSection = new SettingsDataSection();
+        this.googleSection = new SettingsGoogleSection();
+        this.googleSection.init();
     }
 
     /**
@@ -91,98 +84,6 @@ class SettingsModal {
                 this.reset();
             });
         }
-
-        // Export button
-        const exportBtn = document.getElementById('export-data-btn');
-        if (exportBtn) {
-            exportBtn.addEventListener('click', () => {
-                this.handleExport();
-            });
-        }
-
-        // Import button  
-        const importBtn = document.getElementById('import-data-btn');
-        if (importBtn) {
-            importBtn.addEventListener('click', () => {
-                const fileInput = document.getElementById('import-file-input');
-                if (fileInput) {
-                    fileInput.click();
-                }
-            });
-        }
-
-        // Import file input
-        const fileInput = document.getElementById('import-file-input');
-        if (fileInput) {
-            fileInput.addEventListener('change', (e) => {
-                if (e.target.files && e.target.files[0]) {
-                    this.handleImport(e.target.files[0]);
-                }
-            });
-        }
-
-        // Google Auth buttons
-        const googleConnectBtn = document.getElementById('google-connect-btn');
-        if (googleConnectBtn) {
-            googleConnectBtn.addEventListener('click', () => {
-                this.handleGoogleConnect();
-            });
-        }
-
-        const googleDisconnectBtn = document.getElementById('google-disconnect-btn');
-        if (googleDisconnectBtn) {
-            googleDisconnectBtn.addEventListener('click', () => {
-                this.handleGoogleDisconnect();
-            });
-        }
-
-        // Google Drive path input (002-google-drive-storage)
-        const googleDrivePathInput = document.getElementById('google-drive-path-input');
-        if (googleDrivePathInput) {
-            googleDrivePathInput.addEventListener('input', (e) => {
-                this.validateGoogleDrivePath(e.target.value);
-            });
-            googleDrivePathInput.addEventListener('blur', (e) => {
-                this.handleGoogleDrivePathChange(e.target.value);
-            });
-        }
-
-        const saveGoogleDrivePathBtn = document.getElementById('save-google-drive-path-btn');
-        if (saveGoogleDrivePathBtn) {
-            saveGoogleDrivePathBtn.addEventListener('click', () => {
-                const input = document.getElementById('google-drive-path-input');
-                if (input) {
-                    this.saveGoogleDrivePath(input.value);
-                }
-            });
-        }
-
-        // Test connection button (T085)
-        const testConnectionBtn = document.getElementById('test-connection-btn');
-        if (testConnectionBtn) {
-            testConnectionBtn.addEventListener('click', () => {
-                this.handleTestConnection();
-            });
-        }
-
-        // 同步管理按鈕 (sync-files, Issue #19)
-        const syncPanelBtn = document.getElementById('open-sync-panel-btn');
-        if (syncPanelBtn) {
-            syncPanelBtn.addEventListener('click', () => {
-                if (window.syncPanel) {
-                    this.hide();
-                    window.syncPanel.show();
-                }
-            });
-        }
-
-        // Storage mode radio buttons (002-google-drive-storage)
-        const storageModeRadios = document.querySelectorAll('.storage-mode-radio');
-        storageModeRadios.forEach(radio => {
-            radio.addEventListener('change', (e) => {
-                this.handleStorageModeChange(e.target.value);
-            });
-        });
 
         // Layout mode radio buttons
         const layoutModeRadios = document.querySelectorAll('.layout-mode-radio');
@@ -410,29 +311,34 @@ class SettingsModal {
     }
 
     /**
+     * Initialize pendingSettings from current saved settings (if not already set)
+     */
+    _initPendingSettings() {
+        if (!this.pendingSettings) {
+            this.pendingSettings = JSON.parse(JSON.stringify(this.settingsManager.getSettings()));
+        }
+    }
+
+    /**
+     * Set all radio inputs in a named group to match the given value
+     * @param {string} name - The radio group name attribute
+     * @param {string} value - The value to select
+     */
+    _setRadioGroup(name, value) {
+        document.querySelectorAll(`input[name="${name}"]`)
+            .forEach(radio => { radio.checked = radio.value === value; });
+    }
+
+    /**
      * Load current settings into the modal form
      */
     loadCurrentSettings() {
         const settings = this.settingsManager.getSettings();
         const uiSettings = settings.ui;
 
-        // Update theme radio buttons
-        const themeMode = this.settingsManager.getThemeMode();
-        const lightRadio = document.getElementById('theme-light');
-        const darkRadio = document.getElementById('theme-dark');
-        if (lightRadio && darkRadio) {
-            lightRadio.checked = themeMode === 'light';
-            darkRadio.checked = themeMode === 'dark';
-        }
-
-        // Update layout mode radio buttons
-        const layoutMode = this.settingsManager.getLayoutMode();
-        const focusedRadio = document.getElementById('layout-mode-focused');
-        const classicRadio = document.getElementById('layout-mode-classic');
-        if (focusedRadio && classicRadio) {
-            focusedRadio.checked = layoutMode === 'focused';
-            classicRadio.checked = layoutMode === 'classic';
-        }
+        // Update theme and layout mode radio buttons
+        this._setRadioGroup('theme-mode', this.settingsManager.getThemeMode());
+        this._setRadioGroup('layout-mode', this.settingsManager.getLayoutMode());
 
         // Update card order list
         this.renderCardOrderList();
@@ -475,10 +381,7 @@ class SettingsModal {
         const planType = toggle.dataset.type;
         const isChecked = toggle.checked;
 
-        // Create or update pending settings
-        if (!this.pendingSettings) {
-            this.pendingSettings = JSON.parse(JSON.stringify(this.settingsManager.getSettings()));
-        }
+        this._initPendingSettings();
 
         // Update the pending setting
         if (!this.pendingSettings.ui.panels[panelSide]) {
@@ -496,10 +399,7 @@ class SettingsModal {
         const radio = event.target;
         const newMode = radio.value;
 
-        // Create or update pending settings
-        if (!this.pendingSettings) {
-            this.pendingSettings = JSON.parse(JSON.stringify(this.settingsManager.getSettings()));
-        }
+        this._initPendingSettings();
 
         // Update the pending theme mode
         if (!this.pendingSettings.ui.theme) {
@@ -517,17 +417,10 @@ class SettingsModal {
         const newMode = this.settingsManager.toggleTheme();
 
         // Update the radio buttons to reflect the change
-        const lightRadio = document.getElementById('theme-light');
-        const darkRadio = document.getElementById('theme-dark');
-        if (lightRadio && darkRadio) {
-            lightRadio.checked = newMode === 'light';
-            darkRadio.checked = newMode === 'dark';
-        }
+        this._setRadioGroup('theme-mode', newMode);
 
         // Update pending settings if modal is open
-        if (!this.pendingSettings) {
-            this.pendingSettings = JSON.parse(JSON.stringify(this.settingsManager.getSettings()));
-        }
+        this._initPendingSettings();
         this.pendingSettings.ui.theme.mode = newMode;
 
         console.log(`Theme toggled to: ${newMode}`);
@@ -540,10 +433,7 @@ class SettingsModal {
         const toggle = event.target;
         const isEnabled = toggle.checked;
 
-        // Create or update pending settings
-        if (!this.pendingSettings) {
-            this.pendingSettings = JSON.parse(JSON.stringify(this.settingsManager.getSettings()));
-        }
+        this._initPendingSettings();
 
         // Update the pending auto-save enabled setting
         if (!this.pendingSettings.ui.autoSave) {
@@ -570,10 +460,7 @@ class SettingsModal {
             input.value = 60;
         }
 
-        // Create or update pending settings
-        if (!this.pendingSettings) {
-            this.pendingSettings = JSON.parse(JSON.stringify(this.settingsManager.getSettings()));
-        }
+        this._initPendingSettings();
 
         // Update the pending auto-save delay setting
         if (!this.pendingSettings.ui.autoSave) {
@@ -592,9 +479,7 @@ class SettingsModal {
      * Handle layout mode change
      */
     onLayoutModeChange(mode) {
-        if (!this.pendingSettings) {
-            this.pendingSettings = JSON.parse(JSON.stringify(this.settingsManager.getSettings()));
-        }
+        this._initPendingSettings();
         if (!this.pendingSettings.layout) {
             this.pendingSettings.layout = this.settingsManager.getDefaultSettings().layout;
         }
@@ -689,9 +574,7 @@ class SettingsModal {
         });
 
         // Store in pending settings
-        if (!this.pendingSettings) {
-            this.pendingSettings = JSON.parse(JSON.stringify(this.settingsManager.getSettings()));
-        }
+        this._initPendingSettings();
         if (!this.pendingSettings.layout) {
             this.pendingSettings.layout = this.settingsManager.getDefaultSettings().layout;
         }
@@ -767,615 +650,6 @@ class SettingsModal {
         }
     }
 
-    /**
-     * Handle data export
-     */
-    async handleExport() {
-        try {
-            Utils.showLoading('正在匯出資料...');
-            
-            const result = await window.planAPI.exportData();
-            
-            Utils.showSuccess(`成功匯出 ${result.file_count} 個檔案`);
-            
-            // Trigger download
-            window.planAPI.downloadExport(result.filename);
-            
-        } catch (error) {
-            console.error('Export failed:', error);
-            Utils.showError('匯出失敗: ' + error.message);
-        } finally {
-            Utils.hideLoading();
-        }
-    }
-
-    /**
-     * Handle data import (placeholder for US2/US3)
-     */
-    async handleImport(file) {
-        if (!file) {
-            Utils.showError('請選擇要匯入的 ZIP 檔案');
-            return;
-        }
-
-        try {
-            Utils.showLoading('正在驗證檔案...');
-
-            // 呼叫驗證 API
-            const validation = await window.planAPI.validateImport(file);
-
-            Utils.hideLoading();
-
-            // 如果有錯誤,顯示錯誤訊息並中斷
-            if (!validation.is_valid) {
-                const errorMessages = validation.errors.map(err => 
-                    `• ${err.message}`
-                ).join('\n');
-                
-                Utils.showError(
-                    `驗證失敗,發現 ${validation.errors.length} 個錯誤:\n\n${errorMessages}\n\n請修正後重新上傳。`
-                );
-                return;
-            }
-
-            // 如果有警告,顯示但不中斷
-            if (validation.warnings && validation.warnings.length > 0) {
-                const warningMessages = validation.warnings.map(warn => 
-                    `• ${warn.message}`
-                ).join('\n');
-                
-                console.warn('驗證警告:', warningMessages);
-            }
-
-            // 驗證通過,詢問是否繼續匯入
-            const confirmMessage = `驗證通過!\n\n` +
-                `檔案數量: ${validation.file_count} 個\n` +
-                (validation.warnings?.length > 0 ? `警告: ${validation.warnings.length} 個\n` : '') +
-                `\n確定要匯入這些資料嗎?\n(將覆蓋現有的同名檔案)`;
-
-            if (!confirm(confirmMessage)) {
-                Utils.showError('已取消匯入');
-                return;
-            }
-
-            // 執行匯入
-            Utils.showLoading('正在匯入資料...');
-            
-            const importResult = await window.planAPI.executeImport(file);
-            
-            Utils.hideLoading();
-            Utils.showSuccess(
-                `${importResult.message}\n\n` +
-                `匯入時間: ${new Date(importResult.imported_at).toLocaleString('zh-TW')}`
-            );
-
-            // 重新整理頁面以顯示新資料
-            setTimeout(() => {
-                window.location.reload();
-            }, 2000);
-
-        } catch (error) {
-            Utils.hideLoading();
-            Utils.showError(`匯入失敗: ${error.message}`);
-            console.error('Import error:', error);
-        }
-    }
-
-    // ========================================
-    // Google Auth Methods (002-google-drive-storage)
-    // ========================================
-
-    /**
-     * Load Google auth status
-     */
-    async loadGoogleAuthStatus() {
-        try {
-            if (window.googleAuthManager) {
-                await window.googleAuthManager.init();
-                this.googleAuthStatus = await window.googleAuthManager.getAuthStatus();
-                this.updateGoogleAuthUI();
-            }
-        } catch (error) {
-            console.error('Failed to load Google auth status:', error);
-            this.googleAuthStatus = { status: 'not_connected' };
-            this.updateGoogleAuthUI();
-        }
-    }
-
-    /**
-     * Update Google auth UI based on current status
-     */
-    updateGoogleAuthUI() {
-        const statusContainer = document.getElementById('google-auth-status');
-        const connectBtn = document.getElementById('google-connect-btn');
-        const disconnectBtn = document.getElementById('google-disconnect-btn');
-        const emailDisplay = document.getElementById('google-connected-email');
-
-        if (!statusContainer) return;
-
-        const status = this.googleAuthStatus;
-        const isConnected = status && status.status === 'connected';
-
-        if (connectBtn) {
-            connectBtn.style.display = isConnected ? 'none' : 'inline-block';
-        }
-
-        if (disconnectBtn) {
-            disconnectBtn.style.display = isConnected ? 'inline-block' : 'none';
-        }
-
-        if (emailDisplay) {
-            if (isConnected && status.user_email) {
-                emailDisplay.textContent = status.user_email;
-                emailDisplay.parentElement.style.display = 'flex';
-            } else {
-                emailDisplay.parentElement.style.display = 'none';
-            }
-        }
-
-        // Update status indicator
-        const statusIndicator = document.getElementById('google-auth-indicator');
-        if (statusIndicator) {
-            if (isConnected) {
-                statusIndicator.className = 'w-2 h-2 rounded-full bg-green-500';
-                statusIndicator.title = '已連結';
-            } else if (status && status.status === 'expired') {
-                statusIndicator.className = 'w-2 h-2 rounded-full bg-yellow-500';
-                statusIndicator.title = '授權過期';
-            } else {
-                statusIndicator.className = 'w-2 h-2 rounded-full bg-gray-400';
-                statusIndicator.title = '未連結';
-            }
-        }
-
-        // Update storage UI when auth status changes
-        this.updateStorageUI();
-
-        // 顯示/隱藏同步管理按鈕
-        const syncSection = document.getElementById('sync-management-section');
-        if (syncSection) {
-            syncSection.style.display = isConnected ? 'block' : 'none';
-        }
-    }
-
-    /**
-     * Handle Google account connection
-     */
-    async handleGoogleConnect() {
-        try {
-            Utils.showLoading('正在連結 Google 帳號...');
-
-            const result = await window.googleAuthManager.startAuth();
-            
-            this.googleAuthStatus = result;
-            this.updateGoogleAuthUI();
-            
-            // Reload storage status to get latest settings
-            await this.loadStorageStatus();
-            
-            // Reload all plans to reflect data from current storage mode
-            if (window.app && typeof window.app.refreshAllPlans === 'function') {
-                await window.app.refreshAllPlans();
-            }
-            
-            Utils.hideLoading();
-            Utils.showSuccess('已成功連結 Google 帳號');
-            
-        } catch (error) {
-            Utils.hideLoading();
-            console.error('Google connect failed:', error);
-            Utils.showError('連結 Google 帳號失敗: ' + error.message);
-        }
-    }
-
-    /**
-     * Handle Google account disconnection
-     */
-    async handleGoogleDisconnect() {
-        if (!confirm('確定要解除 Google 帳號連結嗎？')) {
-            return;
-        }
-
-        try {
-            Utils.showLoading('正在解除連結...');
-
-            // If currently in Google Drive mode, switch to local first
-            const wasGoogleDriveMode = this.storageStatus?.mode === 'google_drive';
-            if (wasGoogleDriveMode) {
-                try {
-                    const result = await window.planAPI.updateStorageMode('local', this.storageStatus?.google_drive_path);
-                    this.storageStatus = result;
-                    this.updateStorageModeUI();
-                    this.updateStorageUI();
-                    
-                    // Dispatch event to update header icon
-                    window.dispatchEvent(new CustomEvent('storage-mode-changed', {
-                        detail: { mode: 'local', status: result }
-                    }));
-                } catch (switchError) {
-                    console.warn('Failed to switch storage mode, continuing with logout:', switchError);
-                }
-            }
-
-            if (window.googleAuthManager) {
-                await window.googleAuthManager.logout();
-            }
-
-            this.googleAuthStatus = { status: 'not_connected' };
-            this.updateGoogleAuthUI();
-            
-            // Reload all plans to reflect data from local storage
-            if (window.app && typeof window.app.refreshAllPlans === 'function') {
-                await window.app.refreshAllPlans();
-            }
-            
-            Utils.hideLoading();
-            Utils.showSuccess('已解除 Google 帳號連結');
-            
-        } catch (error) {
-            Utils.hideLoading();
-            console.error('Google disconnect failed:', error);
-            Utils.showError('解除連結失敗: ' + error.message);
-        }
-    }
-
-    // ========================================
-    // Storage Settings Methods (002-google-drive-storage)
-    // ========================================
-
-    /**
-     * Load storage status
-     */
-    async loadStorageStatus() {
-        try {
-            this.storageStatus = await window.planAPI.getStorageStatus();
-            this.updateStorageUI();
-            this.updateStorageModeUI();
-        } catch (error) {
-            console.error('Failed to load storage status:', error);
-            this.storageStatus = null;
-        }
-    }
-
-    /**
-     * Update storage UI based on current status
-     */
-    updateStorageUI() {
-        const pathInput = document.getElementById('google-drive-path-input');
-        const pathError = document.getElementById('google-drive-path-error');
-        const saveBtn = document.getElementById('save-google-drive-path-btn');
-        const pathContainer = document.getElementById('google-drive-path-container');
-
-        if (pathInput && this.storageStatus) {
-            pathInput.value = this.storageStatus.google_drive_path || 'WorkPlanByCalendar';
-        }
-
-        // Show/hide path container based on Google auth status
-        if (pathContainer) {
-            const isConnected = this.googleAuthStatus?.status === 'connected';
-            pathContainer.style.display = isConnected ? 'block' : 'none';
-        }
-
-        // Clear error on load
-        if (pathError) {
-            pathError.textContent = '';
-            pathError.style.display = 'none';
-        }
-    }
-
-    /**
-     * Validate Google Drive path input
-     * @param {string} path - Path to validate
-     * @returns {object} Validation result { isValid, message }
-     */
-    validateGoogleDrivePath(path) {
-        const pathError = document.getElementById('google-drive-path-error');
-        const pathInput = document.getElementById('google-drive-path-input');
-        const saveBtn = document.getElementById('save-google-drive-path-btn');
-
-        let isValid = true;
-        let message = '';
-
-        // Validation rules
-        if (!path || path.trim().length === 0) {
-            isValid = false;
-            message = '路徑不可為空';
-        } else if (path.length > 255) {
-            isValid = false;
-            message = '路徑長度不可超過 255 字元';
-        } else if (path.includes('..')) {
-            isValid = false;
-            message = '路徑不可包含 ".."';
-        } else if (path.startsWith('/')) {
-            isValid = false;
-            message = '路徑必須為相對路徑（不可以 "/" 開頭）';
-        } else if (/[<>:"|?*]/.test(path)) {
-            isValid = false;
-            message = '路徑包含無效字元（不可包含 <>:"|?*）';
-        }
-
-        // Update UI
-        if (pathError) {
-            if (isValid) {
-                pathError.style.display = 'none';
-                pathError.textContent = '';
-            } else {
-                pathError.style.display = 'block';
-                pathError.textContent = message;
-            }
-        }
-
-        if (pathInput) {
-            if (isValid) {
-                pathInput.classList.remove('border-red-500');
-                pathInput.classList.add('border-gray-300', 'dark:border-gray-600');
-            } else {
-                pathInput.classList.remove('border-gray-300', 'dark:border-gray-600');
-                pathInput.classList.add('border-red-500');
-            }
-        }
-
-        if (saveBtn) {
-            saveBtn.disabled = !isValid;
-        }
-
-        return { isValid, message };
-    }
-
-    /**
-     * Handle Google Drive path change (on blur)
-     * @param {string} path - New path value
-     */
-    handleGoogleDrivePathChange(path) {
-        const trimmedPath = path.trim();
-        const pathInput = document.getElementById('google-drive-path-input');
-        
-        if (pathInput) {
-            pathInput.value = trimmedPath;
-        }
-        
-        this.validateGoogleDrivePath(trimmedPath);
-    }
-
-    /**
-     * Save Google Drive path
-     * @param {string} path - Path to save
-     */
-    async saveGoogleDrivePath(path) {
-        const trimmedPath = path.trim();
-        
-        // Validate before saving
-        const validation = this.validateGoogleDrivePath(trimmedPath);
-        if (!validation.isValid) {
-            Utils.showError(validation.message);
-            return;
-        }
-
-        // Check if path actually changed
-        if (this.storageStatus?.google_drive_path === trimmedPath) {
-            Utils.showSuccess('路徑未變更');
-            return;
-        }
-
-        try {
-            Utils.showLoading('正在儲存路徑設定...');
-            
-            const result = await window.planAPI.updateGoogleDrivePath(trimmedPath);
-            
-            // Update local state
-            if (this.storageStatus) {
-                this.storageStatus.google_drive_path = trimmedPath;
-            }
-            
-            Utils.hideLoading();
-            Utils.showSuccess('Google Drive 路徑已更新');
-            
-        } catch (error) {
-            Utils.hideLoading();
-            console.error('Failed to save Google Drive path:', error);
-            Utils.showError('儲存失敗: ' + error.message);
-        }
-    }
-
-    /**
-     * Handle storage mode change
-     * @param {string} newMode - New storage mode ('local' or 'google_drive')
-     */
-    async handleStorageModeChange(newMode) {
-        const currentMode = this.storageStatus?.mode || 'local';
-        
-        // If no change, do nothing
-        if (newMode === currentMode) {
-            return;
-        }
-
-        // If switching to Google Drive, check auth status
-        if (newMode === 'google_drive') {
-            if (this.googleAuthStatus?.status !== 'connected') {
-                Utils.showError('請先連結 Google 帳號才能切換到 Google Drive 模式');
-                // Reset radio button
-                this.updateStorageModeUI();
-                return;
-            }
-            
-            // Show confirmation dialog
-            if (!await this.confirmStorageModeSwitch('google_drive')) {
-                this.updateStorageModeUI();
-                return;
-            }
-        } else if (currentMode === 'google_drive') {
-            // Switching from Google Drive to local
-            if (!await this.confirmStorageModeSwitch('local')) {
-                this.updateStorageModeUI();
-                return;
-            }
-        }
-
-        // Execute mode switch
-        await this.executeStorageModeSwitch(newMode);
-    }
-
-    /**
-     * Confirm storage mode switch
-     * @param {string} targetMode - Target storage mode
-     * @returns {Promise<boolean>} User confirmation result
-     */
-    async confirmStorageModeSwitch(targetMode) {
-        let message;
-        
-        if (targetMode === 'google_drive') {
-            message = `確定要切換到 Google Drive 模式嗎？\n\n` +
-                `切換後：\n` +
-                `• 計畫資料將儲存到 Google Drive\n` +
-                `• 需要網路連線才能存取資料\n` +
-                `• 現有本地資料不會自動同步`;
-        } else {
-            message = `確定要切換回本地模式嗎？\n\n` +
-                `切換後：\n` +
-                `• 計畫資料將儲存在本機\n` +
-                `• Google Drive 上的資料不會自動同步到本機`;
-        }
-        
-        return confirm(message);
-    }
-
-    /**
-     * Execute storage mode switch
-     * @param {string} newMode - New storage mode
-     */
-    async executeStorageModeSwitch(newMode) {
-        try {
-            Utils.showLoading('正在切換儲存模式...');
-            
-            const googleDrivePath = this.storageStatus?.google_drive_path;
-            const result = await window.planAPI.updateStorageMode(newMode, googleDrivePath);
-            
-            // Update local state
-            this.storageStatus = result;
-            this.updateStorageModeUI();
-            this.updateStorageUI();
-            
-            // Reload all plans to reflect data from new storage mode
-            if (window.app && typeof window.app.refreshAllPlans === 'function') {
-                await window.app.refreshAllPlans();
-            }
-            
-            Utils.hideLoading();
-            
-            const modeText = newMode === 'google_drive' ? 'Google Drive' : '本地';
-            Utils.showSuccess(`已切換到${modeText}模式`);
-            
-            // Dispatch event for other components to react
-            window.dispatchEvent(new CustomEvent('storage-mode-changed', {
-                detail: { mode: newMode, status: result }
-            }));
-
-            // 切換到 Google Drive 模式時，自動開啟同步面板並比較
-            if (newMode === 'google_drive' && window.syncPanel) {
-                this.hide();  // 先關閉設定 Modal
-                window.syncPanel.show(true);  // 開啟同步面板並自動比較
-            }
-
-        } catch (error) {
-            Utils.hideLoading();
-            console.error('Storage mode switch failed:', error);
-            
-            // Reset UI to current state
-            this.updateStorageModeUI();
-            
-            // Show appropriate error message
-            if (error.message.includes('尚未完全實作')) {
-                Utils.showError('Google Drive 功能尚在開發中，敬請期待！');
-            } else {
-                Utils.showError('切換儲存模式失敗: ' + error.message);
-            }
-        }
-    }
-
-    /**
-     * Update storage mode UI
-     */
-    updateStorageModeUI() {
-        const currentMode = this.storageStatus?.mode || 'local';
-        const localRadio = document.getElementById('storage-mode-local');
-        const googleDriveRadio = document.getElementById('storage-mode-google-drive');
-
-        if (localRadio) {
-            localRadio.checked = currentMode === 'local';
-        }
-        if (googleDriveRadio) {
-            googleDriveRadio.checked = currentMode === 'google_drive';
-            // Disable Google Drive option if not connected
-            const isConnected = this.googleAuthStatus?.status === 'connected';
-            googleDriveRadio.disabled = !isConnected;
-            
-            const label = document.querySelector('label[for="storage-mode-google-drive"]');
-            if (label) {
-                if (isConnected) {
-                    label.classList.remove('opacity-50', 'cursor-not-allowed');
-                } else {
-                    label.classList.add('opacity-50', 'cursor-not-allowed');
-                }
-            }
-        }
-    }
-
-    /**
-     * Handle test connection button click (T085)
-     */
-    async handleTestConnection() {
-        try {
-            Utils.showLoading('正在測試連線...');
-            
-            const result = await window.planAPI.testGoogleDriveConnection();
-            
-            Utils.hideLoading();
-            
-            if (result.success) {
-                const details = result.details || {};
-                const message = `✓ ${result.message}\n\n` +
-                    `帳號: ${details.user_email || 'N/A'}\n` +
-                    `資料夾: ${details.base_folder || 'N/A'}\n` +
-                    `檔案數: ${details.file_count || 0}`;
-                Utils.showSuccess(message);
-            } else {
-                this.showGoogleDriveError(result);
-            }
-        } catch (error) {
-            Utils.hideLoading();
-            console.error('Connection test failed:', error);
-            Utils.showError('連線測試失敗: ' + error.message);
-        }
-    }
-
-    /**
-     * Show Google Drive error with friendly message (T086-T087)
-     * @param {object} result - Error result from API
-     */
-    showGoogleDriveError(result) {
-        const errorType = result.details?.error_type;
-        let message = result.message;
-        let suggestion = '';
-        
-        switch (errorType) {
-            case 'not_connected':
-                suggestion = '請先在設定中連結您的 Google 帳號';
-                break;
-            case 'auth_expired':
-                suggestion = '請重新連結 Google 帳號以更新授權';
-                break;
-            case 'network':
-                suggestion = '請檢查您的網路連線後再試';
-                break;
-            case 'quota_exceeded':
-                suggestion = '請稍後再試，或聯繫 Google 了解配額限制';
-                break;
-            default:
-                suggestion = '如果問題持續發生，請嘗試重新連結 Google 帳號';
-        }
-        
-        Utils.showError(`${message}\n\n${suggestion}`);
-    }
 }
 
 // Export for use in other modules


### PR DESCRIPTION
## Summary

- 將 1382 行的 `settings-modal.js` 按職責拆分成三個獨立檔案，主檔案減少 53%
- 新建 `settings-data.js`（137 行）：負責資料 tab 的匯入/匯出功能
- 新建 `settings-google.js`（610 行）：負責雲端 tab 的 Google 認證、Drive 路徑管理、儲存模式切換
- 提取 `_initPendingSettings()` helper，取代 6 處重複的深拷貝模式
- 提取 `_setRadioGroup()` helper，取代重複的 radio button 狀態設定

## Test plan

- [ ] 開啟 Settings modal，確認 5 個 tab 可正常切換
- [ ] 外觀 tab：切換主題（淺色/深色）→ 儲存 → 重新整理確認保留
- [ ] 佈局 tab：切換佈局模式 → 儲存 → 頁面應重載
- [ ] 面板 tab：隱藏某個面板 → 儲存 → 確認效果
- [ ] 資料 tab：匯出 zip、匯入 zip 流程正常
- [ ] 雲端 tab：Google 連結/中斷連結流程
- [ ] 雲端 tab：Storage mode 切換（local ↔ Google Drive）